### PR TITLE
Pub dev 0.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ migrate_working_dir/
 **/doc/api/
 .dart_tool/
 build/
+example/.flutter-plugins

--- a/.pubignore
+++ b/.pubignore
@@ -1,9 +1,9 @@
-  example/.flutter-plugins
-    example/.idea
-    example/.pub-cache
-    example/.pub
-    example/.vscode
-    example/android/app/debug
-    example/android/app/profile
-    example/android/app/release
-    example/build
+example/.flutter-plugins
+example/.idea
+example/.pub-cache
+example/.pub
+example/.vscode
+example/android/app/debug
+example/android/app/profile
+example/android/app/release
+example/build

--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,9 @@
+  example/.flutter-plugins
+    example/.idea
+    example/.pub-cache
+    example/.pub
+    example/.vscode
+    example/android/app/debug
+    example/android/app/profile
+    example/android/app/release
+    example/build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.1.3] - 2025-02-06
+### Changed
+- Enhanced `convertKeysToSnakeCase` to support recursive conversion of nested maps and lists, ensuring consistent `snake_case` formatting for deeply nested device information.
+
+### Fixed
+- Addressed an issue where nested maps and lists were not properly converted to `snake_case`, leading to inconsistent data formats.
+
 ## [0.1.2] - 2024-08-22
 ### Added
 - Added documentation comments to public members of the `Biometry` class to resolve `public_member_api_docs` lint warnings.
@@ -15,4 +22,3 @@
 - Initial release of the Biometry package.
 - Added support for video processing for biometric verification.
 - Included seamless integration with the Biometry API.
-

--- a/example/.flutter-plugins
+++ b/example/.flutter-plugins
@@ -1,4 +1,0 @@
-# This is a generated file; do not edit or check into version control.
-device_info_plus=/Users/rleidl/.pub-cache/hosted/pub.dev/device_info_plus-11.2.2/
-file_picker=/Users/rleidl/.pub-cache/hosted/pub.dev/file_picker-8.3.1/
-flutter_plugin_android_lifecycle=/Users/rleidl/.pub-cache/hosted/pub.dev/flutter_plugin_android_lifecycle-2.0.21/

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -43,4 +43,4 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
-!/pubspec.lock
+


### PR DESCRIPTION
This pull request includes updates to the `.pubignore` file, enhancements and fixes in the `CHANGELOG.md`, and adjustments to the `.gitignore` file. The changes aim to improve file management and ensure consistent data formatting.

Updates to file management:

* [`.pubignore`](diffhunk://#diff-ae7d49396db673bff412c96ef2a52b60f24ec2645e86ec611d2dfb1490118747R1-R9): Added various directories and files to be ignored, including `.flutter-plugins`, `.idea`, `.pub-cache`, `.pub`, `.vscode`, and build directories.
* [`example/.flutter-plugins`](diffhunk://#diff-034dfe4d35f7cf2127613644b7d1067a85ecf2a6eb821fd368542950010d85afL1-L4): Removed generated file entries to prevent them from being checked into version control.
* [`example/.gitignore`](diffhunk://#diff-4f949cc60169897e1d90defc653b66807239c97ca8237855d41e481370a5a91cL46-R46): Adjusted ignored directories and removed an exception for `pubspec.lock`.

Enhancements and fixes:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R7): Documented the enhancement of the `convertKeysToSnakeCase` function to support recursive conversion of nested maps and lists, ensuring consistent `snake_case` formatting. Also addressed an issue with inconsistent data formats in nested structures. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R7) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL18)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**  
  - Improved data formatting by enhancing conversion routines to recursively process nested information, ensuring consistent and reliable presentation across all data layers and resolving previous discrepancies.

- **Chores**  
  - Refined internal configurations by updating ignore rules to exclude redundant build artifacts, cache folders, and IDE-related files—helping to streamline version control and package management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->