### PR TITLE
fix phrase generation

### DIFF
--- a/lib/src/biometry.dart
+++ b/lib/src/biometry.dart
@@ -28,7 +28,7 @@ class Biometry {
   static const String _consentUrl = '$_host/api-consent';
   static int _phrase = 0;
 
-  // Generate a 7-digit number; first digit 1–9 to avoid leading zero.
+  // Generate a 7-digit number with unique digits from 1-9.
 
   final String _token;
   final http.Client _client;
@@ -56,8 +56,8 @@ class Biometry {
     String id = await _fetchSessionId(token, httpClient, fullName);
     final rand = Random.secure();
 
-    // Generate a 7-digit phrase with unique digits using only digits 1-7
-    final digits = [1, 2, 3, 4, 5, 6, 7]..shuffle(rand);
+    final allDigits = [1, 2, 3, 4, 5, 6, 7, 8, 9]..shuffle(rand);
+    final digits = allDigits.take(7).toList();
     Biometry._phrase = int.parse(digits.join());
 
     debugPrint("Phrase: $_phrase");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved numeric phrase generation for biometric verification: phrases are now seven digits long composed of unique, non-repeating digits (selected from 1–9), improving readability and reducing confusion.
  * No changes to setup flow or how you use biometric verification; public interfaces and workflows remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->