### PR TITLE
update biometry dependency to version 1.0.3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  biometry: ^1.0.2
+  biometry: ^1.0.3
 ```
 
 Run:


### PR DESCRIPTION
This pull request updates the `biometry` dependency version in the documentation to ensure users install the latest release.

- Documentation update:
  * Updated the `biometry` version in the `pubspec.yaml` example from `^1.0.2` to `^1.0.3` in `README.md`.