### PR TITLE
fix: restore X-Client-App headers dropped from git history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `docAuth()` accepts optional `provider` and `mrzProvider` overrides.
 - `endSession()` accepts an optional `phoneNumber` to run a SIM-swap fraud check when ending the session.
 - `approveConsent({consentId})` and `getConsentApprovals()`, with a new `ConsentApproval` model (`consentId`, `userId`, `approvedAt`).
+- `clientAppName` and `clientAppVersion` parameters on `Biometry.initialize()`, sent as `X-Client-App` / `X-Client-App-Version` headers on every request (carried forward from 1.0.9).
 
 ### Changed
 - **Migrated to the Biometry v2 REST API** (`/api-gateway/v2/*`) across every endpoint: sessions, document verification, face/voice enrollment, and face matching.
@@ -23,6 +24,25 @@
 - `scanDocument()` now correctly handles the `flutter_doc_scanner` ^0.0.21 API (`ImageScanResult` / `DocScanException`) instead of the old raw `List`/`Map`/`PlatformException` shape — the previous implementation silently returned an empty path on every scan against the actually-resolved plugin version.
 
 **This is a breaking release.** Every consumer needs to: pass `userId` to `initialize()`, replace `processVideo()` calls with the new granular verification methods, and migrate consent handling to the approval-based API. See the [README](README.md) for updated usage examples.
+
+## [1.0.10] - 2026-03-11
+
+_Retroactively added — published to pub.dev but missing from this changelog's history until now._
+
+### Fixed
+- **scanDocument():** Fixed "no image path received" exception by updating the document scanning logic to support the breaking API changes in `flutter_doc_scanner` 0.0.17+ (typed `ImageScanResult` return).
+
+### Changed
+- Updated `flutter_doc_scanner` dependency constraint to `^0.0.18`.
+
+## [1.0.9] - 2026-03-10
+
+_Retroactively added — published to pub.dev but missing from this changelog's history until now._
+
+### Added
+- **Client app metadata headers:** `Biometry.initialize()` accepts two new optional parameters — `clientAppName` and `clientAppVersion`. When provided, `X-Client-App` and `X-Client-App-Version` headers are attached to every request sent to the API gateway (session start/end, docAuth, processVideo, enrolFace, enrolVoice, faceMatch).
+
+No breaking changes.
 
 ## [1.0.8] - 2026-03-03
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ final biometry = await Biometry.initialize(
 );
 ```
 
+Optionally, pass `clientAppName` and `clientAppVersion` to identify your app on every request (sent as the `X-Client-App` and `X-Client-App-Version` headers):
+
+```dart
+final biometry = await Biometry.initialize(
+  token: 'your-api-token',
+  userId: 'user-1234',
+  fullName: 'John Doe',
+  clientAppName: 'MyApp',
+  clientAppVersion: '3.2.1',
+);
+```
+
 ### Displaying the Verification Phrase
 
 ```dart

--- a/lib/src/biometry.dart
+++ b/lib/src/biometry.dart
@@ -51,25 +51,45 @@ class Biometry {
   /// Cached consent approvals, populated on first call to [assertConsent].
   List<ConsentApproval>? _cachedApprovals;
 
+  /// Client app name sent as `X-Client-App` on every API request.
+  final String? _clientAppName;
+
+  /// Client app version sent as `X-Client-App-Version` on every API request.
+  final String? _clientAppVersion;
+
   Biometry._(
     this._token,
     this._client,
     this.sessionId,
     this._userId,
-    this.fullName,
-  );
+    this.fullName, {
+    String? clientAppName,
+    String? clientAppVersion,
+  })  : _clientAppName = clientAppName,
+        _clientAppVersion = clientAppVersion;
 
   /// Initializes the Biometry class with a token, user ID, full name and an optional HTTP client.
+  ///
+  /// [clientAppName] and [clientAppVersion] are optional. When provided, they
+  /// are sent as `X-Client-App` and `X-Client-App-Version` headers on every
+  /// request to the API gateway.
   static Future<Biometry> initialize({
     required String token,
     required String userId,
     required String fullName,
     http.Client? client,
+    String? clientAppName,
+    String? clientAppVersion,
   }) async {
     await _configureAudioSession();
 
     final http.Client httpClient = client ?? http.Client();
-    String id = await _fetchSessionId(token, httpClient);
+    String id = await _fetchSessionId(
+      token,
+      httpClient,
+      clientAppName: clientAppName,
+      clientAppVersion: clientAppVersion,
+    );
     final rand = Random.secure();
 
     final allDigits = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]..shuffle(rand);
@@ -79,7 +99,15 @@ class Biometry {
     if (kDebugMode) {
       debugPrint("Phrase: $_phrase");
     }
-    return Biometry._(token, httpClient, id, userId, fullName);
+    return Biometry._(
+      token,
+      httpClient,
+      id,
+      userId,
+      fullName,
+      clientAppName: clientAppName,
+      clientAppVersion: clientAppVersion,
+    );
   }
 
   /// Disposes the Biometry class.
@@ -121,12 +149,20 @@ class Biometry {
   /// Fetches a new session ID from the API.
   static Future<String> _fetchSessionId(
     String token,
-    http.Client client,
-  ) async {
+    http.Client client, {
+    String? clientAppName,
+    String? clientAppVersion,
+  }) async {
     final uri = Uri.parse('$_apiGatewayV2/sessions?warmup=true');
 
     final request = http.Request('POST', uri)
       ..headers['Authorization'] = 'Bearer $token';
+    if (clientAppName != null && clientAppName.isNotEmpty) {
+      request.headers['X-Client-App'] = clientAppName;
+    }
+    if (clientAppVersion != null && clientAppVersion.isNotEmpty) {
+      request.headers['X-Client-App-Version'] = clientAppVersion;
+    }
 
     final response = await client.send(request);
     final responseBody = await http.Response.fromStream(response);
@@ -169,6 +205,7 @@ class Biometry {
       ..headers['Content-Type'] = 'application/json'
       ..body = body;
 
+    _addClientAppHeaders(request);
     final response = await _client.send(request);
     if (response.statusCode == 200) {
       // clear all files in the temp directory
@@ -267,6 +304,7 @@ class Biometry {
       print('Headers: ${request.headers}');
     }
 
+    _addClientAppHeaders(request);
     final streamedResponse = await _client.send(request);
     final response = await http.Response.fromStream(streamedResponse);
 
@@ -315,6 +353,7 @@ class Biometry {
       print('Fields: ${request.fields}');
     }
 
+    _addClientAppHeaders(request);
     final streamedResponse = await _client.send(request);
     final response = await http.Response.fromStream(streamedResponse);
 
@@ -368,6 +407,7 @@ class Biometry {
       ));
 
     // Send the request and wait for the response stream to complete.
+    _addClientAppHeaders(request);
     final streamedResponse = await _client.send(request);
     final response = await http.Response.fromStream(streamedResponse);
 
@@ -434,6 +474,7 @@ class Biometry {
       print("use_session_video: $useSessionVideo");
     }
 
+    _addClientAppHeaders(request);
     final streamedResponse = await _client.send(request);
     final response = await http.Response.fromStream(streamedResponse);
 
@@ -485,6 +526,7 @@ class Biometry {
             MediaType('video', video.path.split('.').last.toLowerCase()),
       ));
 
+    _addClientAppHeaders(request);
     final streamedResponse = await _client.send(request);
     final response = await http.Response.fromStream(streamedResponse);
 
@@ -518,6 +560,7 @@ class Biometry {
             MediaType('video', video.path.split('.').last.toLowerCase()),
       ));
 
+    _addClientAppHeaders(request);
     final streamedResponse = await _client.send(request);
     final response = await http.Response.fromStream(streamedResponse);
 
@@ -552,6 +595,7 @@ class Biometry {
             MediaType('video', video.path.split('.').last.toLowerCase()),
       ));
 
+    _addClientAppHeaders(request);
     final streamedResponse = await _client.send(request);
     final response = await http.Response.fromStream(streamedResponse);
 
@@ -585,6 +629,7 @@ class Biometry {
             MediaType('video', video.path.split('.').last.toLowerCase()),
       ));
 
+    _addClientAppHeaders(request);
     final streamedResponse = await _client.send(request);
     final response = await http.Response.fromStream(streamedResponse);
 
@@ -607,6 +652,7 @@ class Biometry {
       ..headers['Authorization'] = 'Bearer $_token';
 
     debugPrint("request: $request");
+    _addClientAppHeaders(request);
     final response = await _client.send(request);
     final httpResponse = await http.Response.fromStream(response);
     if (httpResponse.statusCode >= 200 && httpResponse.statusCode < 300) {
@@ -688,6 +734,15 @@ class Biometry {
     }
   }
 
+  void _addClientAppHeaders(http.BaseRequest request) {
+    if (_clientAppName != null && _clientAppName!.isNotEmpty) {
+      request.headers['X-Client-App'] = _clientAppName!;
+    }
+    if (_clientAppVersion != null && _clientAppVersion!.isNotEmpty) {
+      request.headers['X-Client-App-Version'] = _clientAppVersion!;
+    }
+  }
+
   String _stripFileUriPrefix(String uri) {
     if (uri.startsWith('file://')) {
       return uri.replaceFirst('file://', '');
@@ -716,7 +771,13 @@ class Biometry {
 
     final response = await _client.get(
       uri,
-      headers: {'Authorization': 'Bearer $_token'},
+      headers: {
+        'Authorization': 'Bearer $_token',
+        if (_clientAppName != null && _clientAppName!.isNotEmpty)
+          'X-Client-App': _clientAppName!,
+        if (_clientAppVersion != null && _clientAppVersion!.isNotEmpty)
+          'X-Client-App-Version': _clientAppVersion!,
+      },
     );
 
     if (response.statusCode < 200 || response.statusCode >= 300) {

--- a/test/biometry_test.dart
+++ b/test/biometry_test.dart
@@ -616,6 +616,61 @@ void main() {
       });
     });
 
+    group('client app headers', () {
+      test('are sent on session start and subsequent requests when provided',
+          () async {
+        final client = MockClient();
+        http.BaseRequest? capturedRequest;
+        when(client.send(any)).thenAnswer((invocation) async {
+          final request = invocation.positionalArguments[0] as http.BaseRequest;
+          capturedRequest = request;
+          if (request.url.toString() == '$v2Base/sessions?warmup=true') {
+            return http.StreamedResponse(
+              bodyStream('{"data":{"session_id":"session-id-456"}}'),
+              200,
+            );
+          } else if (request.url.toString() == '$v2Base/liveness') {
+            return http.StreamedResponse(bodyStream('{"data":{}}'), 200);
+          }
+          fail('Unexpected URL call: ${request.url}');
+        });
+
+        final clientAppBiometry = await Biometry.initialize(
+          token: 'test-token',
+          userId: 'john-doe',
+          fullName: 'John Doe',
+          client: client,
+          clientAppName: 'MyApp',
+          clientAppVersion: '3.2.1',
+        );
+
+        expect(capturedRequest!.headers['X-Client-App'], 'MyApp');
+        expect(capturedRequest!.headers['X-Client-App-Version'], '3.2.1');
+
+        await clientAppBiometry.livenessCheck(video: mockFile);
+
+        expect(capturedRequest!.headers['X-Client-App'], 'MyApp');
+        expect(capturedRequest!.headers['X-Client-App-Version'], '3.2.1');
+      });
+
+      test('are omitted when not provided', () async {
+        http.BaseRequest? captured;
+        when(mockHttpClient.send(any)).thenAnswer((invocation) async {
+          final request = invocation.positionalArguments[0] as http.BaseRequest;
+          if (request.url.toString() == '$v2Base/liveness') {
+            captured = request;
+            return http.StreamedResponse(bodyStream('{"data":{}}'), 200);
+          }
+          fail('Unexpected URL call: ${request.url}');
+        });
+
+        await biometry.livenessCheck(video: mockFile);
+
+        expect(captured!.headers.containsKey('X-Client-App'), isFalse);
+        expect(captured!.headers.containsKey('X-Client-App-Version'), isFalse);
+      });
+    });
+
     group('phrase utilities', () {
       test('phraseWords spells out each digit of the phrase', () {
         Biometry.resetPhrase();


### PR DESCRIPTION
## Summary
While attempting to publish 2.0.0, discovered pub.dev's latest published version (1.0.10) contains work that was never merged into this repo's git history — meaning it was published from somewhere outside this GitHub repo's tracked branches.

Diffing the published 1.0.9/1.0.10 source against git's 1.0.8 commit found:
- **1.0.9**: Added `clientAppName`/`clientAppVersion` params to `initialize()`, sent as `X-Client-App`/`X-Client-App-Version` headers on every request. **This is the only genuine gap** — not in git, so not in the 2.0.0 rewrite either.
- **1.0.10**: Fixed the same `flutter_doc_scanner` breaking-API bug independently fixed in BM-345 (#18) — no functional gap, just independently discovered and fixed twice.

This PR restores the client-app-header feature for v2.0.0 and retroactively documents the 1.0.9/1.0.10 CHANGELOG entries (using their published text) so they don't vanish from the historical record.

## Changes
- `Biometry.initialize()` gains optional `clientAppName`/`clientAppVersion` params
- New `_addClientAppHeaders()` helper wires them into every outgoing request (session start, all verification/enrollment/consent calls)
- README documents the new params
- CHANGELOG: added a bullet to `[2.0.0]`, plus retroactive `[1.0.9]`/`[1.0.10]` entries

## Test plan
- [x] `flutter analyze` — 0 errors/warnings
- [x] `flutter test` — 41/41 passing (2 new tests: headers sent when provided, omitted when not)
- [x] `dart pub publish --dry-run` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional client app name and version settings during Biometry initialization.
  - Client app metadata is included in request headers throughout supported Biometry operations.

- **Documentation**
  - Updated the README and changelog with configuration examples, header details, and historical release information.

- **Bug Fixes**
  - Documented a document-scanning compatibility fix for `flutter_doc_scanner` 0.0.17+.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->