### PR TITLE
docs: note 2.0.0 published to pub.dev in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 **This is a breaking release.** Every consumer needs to: pass `userId` to `initialize()`, replace `processVideo()` calls with the new granular verification methods, and migrate consent handling to the approval-based API. See the [README](README.md) for updated usage examples.
 
+Published to [pub.dev](https://pub.dev/packages/biometry/versions/2.0.0) on 2026-07-23.
+
 ## [1.0.10] - 2026-03-11
 
 _Retroactively added — published to pub.dev but missing from this changelog's history until now._


### PR DESCRIPTION
## Summary
Small changelog-only update closing out the v2 migration effort: notes that 2.0.0 is live on pub.dev (150/160 score, docs verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the version 2.0.0 changelog entry to indicate publication to pub.dev.
  * Added the release version link and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->